### PR TITLE
Rename 'allowedAdminClaims' to 'adminList' in CollectionPaths enum for clarity and consistency.

### DIFF
--- a/lib/src/feature/firebase/enum/collection_paths.dart
+++ b/lib/src/feature/firebase/enum/collection_paths.dart
@@ -6,7 +6,7 @@ enum CollectionPaths {
   approvedApplications,
   notifications,
   logs,
-  allowedAdminClaims,
+  adminList,
   developers,
   categories,
   specialAgency,


### PR DESCRIPTION
This pull request includes a change to the `CollectionPaths` enum in the `lib/src/feature/firebase/enum/collection_paths.dart` file. The change renames an enum member to improve clarity.

* Renamed `allowedAdminClaims` to `adminList` in the `CollectionPaths` enum.