### PR TITLE
Refactor timestamp handling in models to simplify JSON serialization. 

### DIFF
--- a/lib/src/models/ad_board_model.g.dart
+++ b/lib/src/models/ad_board_model.g.dart
@@ -14,12 +14,10 @@ AdBoardModel _$AdBoardModelFromJson(Map<String, dynamic> json) => AdBoardModel(
       adIndex: (json['adIndex'] as num?)?.toInt(),
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
     );
 
 Map<String, dynamic> _$AdBoardModelToJson(AdBoardModel instance) =>

--- a/lib/src/models/app_notification_model.g.dart
+++ b/lib/src/models/app_notification_model.g.dart
@@ -11,8 +11,7 @@ AppNotificationModel _$AppNotificationModelFromJson(
     AppNotificationModel(
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       body: json['body'] as String?,
       id: json['id'] as String? ?? '',
       title: json['title'] as String?,

--- a/lib/src/models/campaign_model.g.dart
+++ b/lib/src/models/campaign_model.g.dart
@@ -14,8 +14,7 @@ CampaignModel _$CampaignModelFromJson(Map<String, dynamic> json) =>
       publisher: json['publisher'] as String?,
       expireDate: json['expireDate'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['expireDate'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['expireDate']),
       photo: json['photo'] as String?,
       coverPhoto: json['coverPhoto'] as String?,
       isApproved: json['isApproved'] as bool?,

--- a/lib/src/models/chain_store_model.g.dart
+++ b/lib/src/models/chain_store_model.g.dart
@@ -19,12 +19,10 @@ ChainStoreModel _$ChainStoreModelFromJson(Map<String, dynamic> json) =>
           .toList(),
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
       category: json['category'] == null
           ? null
           : CategoryModel.fromJson(json['category'] as Map<String, dynamic>),

--- a/lib/src/models/memory_model.g.dart
+++ b/lib/src/models/memory_model.g.dart
@@ -12,10 +12,8 @@ MemoryModel _$MemoryModelFromJson(Map<String, dynamic> json) => MemoryModel(
       imageUrls: (json['imageUrls'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
-      createdAt: FirebaseTimeParse.datetimeFromTimestamp(
-          json['createdAt'] as Timestamp?),
-      updatedAt: FirebaseTimeParse.datetimeFromTimestamp(
-          json['updatedAt'] as Timestamp?),
+      createdAt: FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
+      updatedAt: FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
     );
 
 Map<String, dynamic> _$MemoryModelToJson(MemoryModel instance) =>

--- a/lib/src/models/news_model.g.dart
+++ b/lib/src/models/news_model.g.dart
@@ -12,12 +12,10 @@ NewsModel _$NewsModelFromJson(Map<String, dynamic> json) => NewsModel(
       image: json['image'] as String?,
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
     );
 
 Map<String, dynamic> _$NewsModelToJson(NewsModel instance) => <String, dynamic>{

--- a/lib/src/models/store_city_model.g.dart
+++ b/lib/src/models/store_city_model.g.dart
@@ -10,12 +10,10 @@ StoreCityModel _$StoreCityModelFromJson(Map<String, dynamic> json) =>
     StoreCityModel(
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
       name: json['name'] as String? ?? '',
     );
 

--- a/lib/src/models/store_model.g.dart
+++ b/lib/src/models/store_model.g.dart
@@ -16,12 +16,10 @@ StoreModel _$StoreModelFromJson(Map<String, dynamic> json) => StoreModel(
       townCode: (json['townCode'] as num).toInt(),
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
       isApproved: json['isApproved'] as bool,
       openTime: json['openTime'] as String?,
       closeTime: json['closeTime'] as String?,

--- a/lib/src/models/useful_links_model.g.dart
+++ b/lib/src/models/useful_links_model.g.dart
@@ -14,12 +14,10 @@ UsefulLinksModel _$UsefulLinksModelFromJson(Map<String, dynamic> json) =>
       image: json['image'] as String?,
       createdAt: json['createdAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['createdAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
       updatedAt: json['updatedAt'] == null
           ? DateTime.now()
-          : FirebaseTimeParse.datetimeFromTimestamp(
-              json['updatedAt'] as Timestamp?),
+          : FirebaseTimeParse.datetimeFromTimestamp(json['updatedAt']),
     );
 
 Map<String, dynamic> _$UsefulLinksModelToJson(UsefulLinksModel instance) =>

--- a/lib/src/utility/firebase_time_parse.dart
+++ b/lib/src/utility/firebase_time_parse.dart
@@ -5,10 +5,30 @@ import 'package:flutter/foundation.dart';
 class FirebaseTimeParse {
   const FirebaseTimeParse._();
 
-  static DateTime? datetimeFromTimestamp(Timestamp? timestamp) {
-    return timestamp != null
-        ? DateTime.fromMillisecondsSinceEpoch(timestamp.millisecondsSinceEpoch)
-        : null;
+  static DateTime? datetimeFromTimestamp(dynamic timestamp) {
+    if (timestamp == null) return null;
+
+    // If it's already a Timestamp, convert it directly
+    if (timestamp is Timestamp) {
+      return DateTime.fromMillisecondsSinceEpoch(
+          timestamp.millisecondsSinceEpoch);
+    }
+
+    // If it's a String, try to parse it as DateTime
+    if (timestamp is String) {
+      try {
+        return DateTime.parse(timestamp);
+      } catch (e) {
+        if (kDebugMode) {
+          print('Error parsing timestamp string: $e');
+        }
+        return null;
+      }
+    }
+    if (kDebugMode) {
+      print('Unsupported timestamp type: ${timestamp.runtimeType}');
+    }
+    return null;
   }
 
   static Timestamp? dateTimeToTimestamp(DateTime? datetime) {

--- a/lib/src/utility/firebase_time_parse.dart
+++ b/lib/src/utility/firebase_time_parse.dart
@@ -20,13 +20,13 @@ class FirebaseTimeParse {
         return DateTime.parse(timestamp);
       } catch (e) {
         if (kDebugMode) {
-          print('Error parsing timestamp string: $e');
+          debugPrint('Error parsing timestamp string: $e');
         }
         return null;
       }
     }
     if (kDebugMode) {
-      print('Unsupported timestamp type: ${timestamp.runtimeType}');
+      debugPrint('Unsupported timestamp type: ${timestamp.runtimeType}');
     }
     return null;
   }

--- a/test/time_of_day_test.mocks.dart
+++ b/test/time_of_day_test.mocks.dart
@@ -22,6 +22,7 @@ import 'package:mockito/src/dummies.dart' as _i3;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeStoreModel_0 extends _i1.SmartFake implements _i2.StoreModel {
   _FakeStoreModel_0(


### PR DESCRIPTION
This pull request updates the handling of Firebase timestamps across several model classes to improve flexibility and robustness. The main change is to allow the timestamp parsing utility to accept multiple input types (such as `Timestamp` and `String`), which helps prevent runtime errors and simplifies the deserialization logic for models.

### Timestamp parsing improvements

* Modified `FirebaseTimeParse.datetimeFromTimestamp` in `lib/src/utility/firebase_time_parse.dart` to accept a dynamic type, handling both `Timestamp` and `String` inputs, with appropriate error handling and debug logging for unsupported types.

### Model deserialization updates

* Updated all model classes (`AdBoardModel`, `AppNotificationModel`, `CampaignModel`, `ChainStoreModel`, `MemoryModel`, `NewsModel`, `StoreCityModel`, `StoreModel`, `UsefulLinksModel`) to use the new dynamic timestamp parsing logic, removing explicit casting to `Timestamp?` and simplifying the deserialization code. [[1]](diffhunk://#diff-4b5c30b11e3b6fb0b96d2862107112229b59e38f7c4b5b3244614d54962ff7c6L17-R20) [[2]](diffhunk://#diff-be30b65902c669d315411f91076e42208cdef7e8624b757382dd2da17b29e872L14-R14) [[3]](diffhunk://#diff-c567f21e817bb3b73e11575d4780cb8e2793feeec8b50bc2512c2de658f72d98L17-R17) [[4]](diffhunk://#diff-5051f47ee095ea1d7a91ed16cf57b087182baafa4d0a272a2511180332f2df83L22-R25) [[5]](diffhunk://#diff-fdb88ec43a7cd5a93e0512dfc9fca0b9490be4c142661991f0cbc8b8cbd24105L15-R16) [[6]](diffhunk://#diff-e5845ab09a357b7fb63507db7d7c212563db5233f31686d5d5f13740882ab6f5L15-R18) [[7]](diffhunk://#diff-a1ff3c8580d875dd376ee7e3ba244b297e92ee17860c3eb24b7f8eba5429f799L13-R16) [[8]](diffhunk://#diff-32e222fc601340143796ae45171bc0139f5ad539a2ea66cde5212cfe0b94b5c0L19-R22) [[9]](diffhunk://#diff-bc21ab11c00d4558d968749115f6180181a71a982f878a94ba831f3c875d2ccdL17-R20)

### Test and code quality

* Added an ignore directive for `invalid_use_of_internal_member` in `test/time_of_day_test.mocks.dart` to suppress warnings related to mock generation.